### PR TITLE
Fix `npm run test` not working in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,7 @@ jobs:
     - run: npm ci
     - run: npm run build --if-present
     - run: npm run test
-      continue-on-error: true
     - run: npm run coverage_ci
-      continue-on-error: true
     - run: echo "COV=$(python3 scripts/cov_parser.py ./cov)" >> $GITHUB_ENV
     - name: create_badge
       uses: schneegans/dynamic-badges-action@v1.4.0    

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,6 @@ const { app } = require('../server.js');
 var io = require('socket.io-client');
 const hand_gesture = require('../public/hand_gesture');
 require('mocha-sinon');
-var expect = require('chai').expect;
 
 // Configure chai
 chai.use(chaiHttp);
@@ -107,23 +106,23 @@ describe('Spark', () => {
     });
 
     describe('Socket emit methods ', function () {
-      it('join-room emit function', function (done) {
-        socket.emit('join-room', 100);
+      it('create or join emit function', function (done) {
+        socket.emit('create or join', 100);
         done();
       });
-      it('user-connected emit function', function (done) {
-        socket.emit('user-connected', 100);
+      it('ready emit function', function (done) {
+        socket.emit('ready', 100);
         done();
       });
-      it('message emit function', function (done) {
-        socket.emit('message', 100);
+      it('candidate emit function', function (done) {
+        socket.emit('candidate', 100);
         done();
       });
-      it('muteAllUsers emit function', function (done) {
-        socket.emit('muteAllUsers', 100);
+      it('offer emit function', function (done) {
+        socket.emit('offer', 100);
         done();
       });
-      it('disconnect emit function', function (done) {
+      it('answer emit function', function (done) {
         socket.emit('answer', 100);
         done();
       });

--- a/test/test.js
+++ b/test/test.js
@@ -107,23 +107,23 @@ describe('Spark', () => {
     });
 
     describe('Socket emit methods ', function () {
-      it('join-room emit function', function (done) {
-        socket.emit('join-room', 100);
+      it('create or join emit function', function (done) {
+        socket.emit('create or join', 100);
         done();
       });
-      it('user-connected emit function', function (done) {
-        socket.emit('user-connected', 100);
+      it('ready emit function', function (done) {
+        socket.emit('ready', 100);
         done();
       });
-      it('message emit function', function (done) {
-        socket.emit('message', 100);
+      it('candidate emit function', function (done) {
+        socket.emit('candidate', 100);
         done();
       });
-      it('muteAllUsers emit function', function (done) {
-        socket.emit('muteAllUsers', 100);
+      it('offer emit function', function (done) {
+        socket.emit('offer', 100);
         done();
       });
-      it('disconnect emit function', function (done) {
+      it('answer emit function', function (done) {
         socket.emit('answer', 100);
         done();
       });

--- a/test/test.js
+++ b/test/test.js
@@ -107,23 +107,23 @@ describe('Spark', () => {
     });
 
     describe('Socket emit methods ', function () {
-      it('create or join emit function', function (done) {
-        socket.emit('create or join', 100);
+      it('join-room emit function', function (done) {
+        socket.emit('join-room', 100);
         done();
       });
-      it('ready emit function', function (done) {
-        socket.emit('ready', 100);
+      it('user-connected emit function', function (done) {
+        socket.emit('user-connected', 100);
         done();
       });
-      it('candidate emit function', function (done) {
-        socket.emit('candidate', 100);
+      it('message emit function', function (done) {
+        socket.emit('message', 100);
         done();
       });
-      it('offer emit function', function (done) {
-        socket.emit('offer', 100);
+      it('muteAllUsers emit function', function (done) {
+        socket.emit('muteAllUsers', 100);
         done();
       });
-      it('answer emit function', function (done) {
+      it('disconnect emit function', function (done) {
         socket.emit('answer', 100);
         done();
       });


### PR DESCRIPTION
Closes #41 

I have no idea why reverting the change to test.js from #40 fixes this issue, but it does for some reason. Maybe the socket emit of actual server-side client socket functions was causing this behind-the-scenes, but only in Linux and not locally... for some reason. Anyways, this still addresses the core objective of #39, so I'm not going to figure out why the revert fixes this. At least removing the unnecessary `expect` variable in test.js didn't break anything. Otherwise, don't touch test.js.